### PR TITLE
テスト用のMysqlを作成する

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,14 @@ services:
       MYSQL_DATABASE: photo_sharing
       MYSQL_USER: root
       TZ: Asia/Tokyo
+
+  mysql_test:
+    build:
+      context: ./docker/mysql
+    ports:
+      - "32801:3306"
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 1
+      MYSQL_DATABASE: photo_sharing
+      MYSQL_USER: root
+      TZ: Asia/Tokyo

--- a/docker/photo-sharing/Dockerfile
+++ b/docker/photo-sharing/Dockerfile
@@ -5,10 +5,12 @@ COPY ./php/php.ini /usr/local/etx/php/php.ini
 
 RUN set -x \
     && apt-get -y update \
-    && apt-get install -y zip unzip git wget libpq-dev \
+    && apt-get install -y zip unzip git wget libpq-dev libfreetype6-dev libjpeg62-turbo-dev libpng-dev \
     && docker-php-ext-install pdo_mysql \
     && pecl install redis-5.1.1 \
-    && docker-php-ext-enable redis
+    && docker-php-ext-enable redis \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) gd
 
 RUN set -x \
     && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \


### PR DESCRIPTION
# 概要
PhpUnitで使用するために、テスト用のmsyqlを作成する

＃対応
test_mysqlのコンテナを作成する

# ついでにやった
ファイルアップロードに関するテストで```imagecreatefromjpeg```を利用する
そのため、php7.4環境にGDライブラリをインストールした